### PR TITLE
Fix Kotlin DSL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ or `build.gradle.kts`:
 import com.jakewharton.wormhole.gradle.wormhole
 
 android {
-  compileSdkVersion wormhole(29)
+  compileSdkVersion(wormhole(29))
 }
 ```
 


### PR DESCRIPTION
`compileSdkVersion` isn't an infix function so parentheses are needed around the argument.